### PR TITLE
Update Spin-2 cQASM spec subset

### DIFF
--- a/docs/appendices/spin.md
+++ b/docs/appendices/spin.md
@@ -17,3 +17,5 @@ The Spin-2 system developed by QuTech supports the following subset of the cQASM
 * All other libqasm 1.x language structures are not supported.
 * No `prep_X` and `measure_X` instructions are allowed, the lls will init all supported qubits before circuit execution
   and measure all in the z-basis at the end of the circuit and only return the subset as defined in the qubit register.
+* Bit register declaration statements, _e.g._, `bit[<number-of-bits:INT>] <bit-register-name:ID>` or `bit <bit-name:ID>`, are accepted and subsequently ignored.
+* Measure instruction statements assign outcomes to bit variables, _e.g._ `<bit-name:BIT> = measure <qubit-argument:QUBIT>`. These statements are accepted and subsequently ignored.

--- a/docs/language_specification/statements/bit_register_declaration_statement.md
+++ b/docs/language_specification/statements/bit_register_declaration_statement.md
@@ -54,5 +54,5 @@ Find below examples, respectively, of a single qubit declaration and qubit regis
         b[1] = measure q[1]
         ```
 
-The individual bits of a bit register can be referred to by their register index, _e.g._ in the example of the _Bit register declaration_, the statement `breg[0] = measure q[0]` indicates that the measurement outcome is stored at the bit located at index `0` of the bit register `breg`. 
+The individual bits of a bit register can be referred to by their register index, _e.g._ in the example of the _Bit register declaration_, the statement `b[0] = measure q[0]` indicates that the measurement outcome is stored at the bit located at index `0` of the bit register `b`. 
 Note that in the case of a single bit, the bit is referred to through its identifier, not through a register index.


### PR DESCRIPTION
Update Spin-2 cQASM spec subset to accept and subsequently ignore statements involving bits/bit registers.