### PR TITLE
Final comments on Improve Syntax Definitions PR

### DIFF
--- a/docs/language_specification/general_overview.md
+++ b/docs/language_specification/general_overview.md
@@ -20,13 +20,17 @@ A cQASM program can contain the following types of tokens:
 
 ## Statements
 
-A cQASM program consists of a sequence of statements:
+A cQASM program consists of a sequence of *statements*.
+Among those, a quantum algorithm is in essence a sequence of *instructions*:
+*gates* and non-unitary quantum operations applied to qubit arguments
+(_e.g._, the [*measure instruction*](measure_instruction.md)).
+
 
 - [Version statement](statements/version_statement.md) (_mandatory_)
 - [Qubit (register) declaration](statements/qubit_register_declaration.md)
 - [Bit (register) declaration](statements/bit_register_declaration.md)
 - [Gates](statements/gates.md)
-- [Measurement statement](statements/measurement_statement.md)
+- [Measure instruction](statements/measure_instruction.md)
 
 !!! example ""
 

--- a/docs/language_specification/statements/bit_register_declaration.md
+++ b/docs/language_specification/statements/bit_register_declaration.md
@@ -23,7 +23,7 @@ The name of the bit (register) is defined through an [identifier](../tokens/iden
 
 The declaration of a bit (register) is _optional_,
 Nevertheless, since measurement outcomes are stored as bits,
-[measurement statements](measurement_statement.md) require a previously declared bit (register).
+[measure instructions](measure_instructions.md) require a previously declared bit (register).
 
 Find below examples, respectively, of a single bit declaration and bit register declaration.
 

--- a/docs/language_specification/statements/bit_register_declaration.md
+++ b/docs/language_specification/statements/bit_register_declaration.md
@@ -23,7 +23,7 @@ The name of the bit (register) is defined through an [identifier](../tokens/iden
 
 The declaration of a bit (register) is _optional_,
 Nevertheless, since measurement outcomes are stored as bits,
-[measure instructions](measure_instructions.md) require a previously declared bit (register).
+[measure instructions](measure_instruction.md) require a previously declared bit (register).
 
 Find below examples, respectively, of a single bit declaration and bit register declaration.
 

--- a/docs/language_specification/statements/gates.md
+++ b/docs/language_specification/statements/gates.md
@@ -1,9 +1,6 @@
 Gates define single-qubit or multi-qubit unitary operations
 that change the state of a qubit register in a deterministic fashion.
-In essence, a quantum algorithm is a sequence of gates
-and non-unitary quantum instructions applied to qubit arguments,
-_e.g._, the [measurement statement](measurement_statement.md).
-The general form of a gate statement is given by the gate name
+The general form of a gate is given by the gate name
 followed by the (comma-separated list of) qubit operand(s), _e.g._, **`X q[0]`**:
 
 !!! info ""
@@ -11,7 +8,7 @@ followed by the (comma-separated list of) qubit operand(s), _e.g._, **`X q[0]`**
     &emsp;_gate qubit-arguments_
 
 Parameterized unitary operations are represented by parameterized gates.
-The general form of a parameterized gate statement is given by the gate name
+The general form of a parameterized gate is given by the gate name
 followed by its (comma-separated list of) parameter(s) that is enclosed in parentheses,
 which in turn is followed by the (comma-separated list of) qubit operand(s), _e.g._, **`CRk(2) q[0], q[1]`**:
 
@@ -58,7 +55,7 @@ and the _qubit arguments_ that a (parameterized) gate acts on.
     _qubit-index_:  
     &emsp; _index_
 
-A few examples of gate statements are shown below.
+A few examples of gates are shown below.
 
 !!! example ""
 
@@ -92,7 +89,7 @@ The single-qubit gate will then be applied to each qubit, respectively.
     whereby a series of instruction statements can be written as one.
     Moreover, SGMQ notation should not be confused with multiple-qubit gates, _e.g._, 
     **`X q[0,1]`** means **`X q[0]; X q[1]`**,
-    and does not represent the 2-qubit gate statement **`XX q[0], q[1]`**.
+    and does not represent the 2-qubit gate **`XX q[0], q[1]`**.
     Note that the latter 2-qubit gate **`XX`** is currently not supported by the cQASM language,
     see the [standard gate set](gates.md#standard-gate-set) below.
 

--- a/docs/language_specification/statements/measure_instruction.md
+++ b/docs/language_specification/statements/measure_instruction.md
@@ -1,16 +1,15 @@
-A measurement statement consists of the application of
-the **`measure`** instruction to its qubit argument and
-the assignment of the resulting measurement outcome to a bit variable.
-The general form of a measurement statement is as follows:
+A **`measure`** instruction performs a measurement to its qubit argument and
+assigns the outcome to a bit variable.
+The general form of a measure instruction is as follows:
 
 !!! info ""
 
-    &emsp;_bit-argument_ **`= measure`** _qubit-argument_
+    &emsp;_bit-argument_ **`=`** **`measure`** _qubit-argument_
 
-??? info "Grammar for measure statement"
+??? info "Grammar for measure instruction"
     
     _measure_:  
-    &emsp; _bit-argument_ __`= measure`__ _qubit-argument_
+    &emsp; _bit-argument_ __`=`__ __`measure`__ _qubit-argument_
 
     _bit-argument_:  
     &emsp; _bit-variable_  
@@ -54,7 +53,7 @@ The general form of a measurement statement is as follows:
 
     The measure instruction accepts [SGMQ notation](gates.md#single-gate-multi-qubit-sgmq-notation), similar to gates.
 
-The following code snippet shows how the measure statement might be used in context
+The following code snippet shows how the measure instruction might be used in context
 
 ```linenums="1" hl_lines="9"
 version 3.0

--- a/docs/language_specification/statements/measure_instruction.md
+++ b/docs/language_specification/statements/measure_instruction.md
@@ -44,16 +44,16 @@ The general form of a measure instruction is as follows:
     === "Measurement of multiple qubits through their register index"
     
         ```linenums="1", hl_lines="3"
-        qubit[5] qreg
-        bit[2] breg
-        breg[0, 1] = measure qreg[2, 4]
+        qubit[5] q
+        bit[2] b
+        b[0, 1] = measure q[2, 4]
         ```
 
 !!! note
 
     The measure instruction accepts [SGMQ notation](gates.md#single-gate-multi-qubit-sgmq-notation), similar to gates.
 
-The following code snippet shows how the measure instruction might be used in context
+The following code snippet shows how the measure instruction might be used in context.
 
 ```linenums="1" hl_lines="9"
 version 3.0

--- a/docs/language_specification/statements/version_statement.md
+++ b/docs/language_specification/statements/version_statement.md
@@ -9,7 +9,7 @@ It has the following general form:
 ??? info "Grammar for version statement"
 
     _version_:  
-    &emsp; _major-version_ _minor-version-suffix_~opt~
+    &emsp;**`version`** _major-version_ _minor-version-suffix_~opt~
 
     _major-version_:  
     &emsp; _digit-sequence_

--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -23,7 +23,7 @@ nav:
       - Qubit (register) declaration: ./language_specification/statements/qubit_register_declaration.md
       - Bit (register) declaration: ./language_specification/statements/bit_register_declaration.md
       - Gates: ./language_specification/statements/gates.md
-      - Measurement statement: ./language_specification/statements/measurement_statement.md
+      - Measure instruction: ./language_specification/statements/measure_instruction.md
     - Types: ./language_specification/types.md
     - Expressions:
       - Indices: ./language_specification/expressions/indices.md


### PR DESCRIPTION
Change `measurement statement` term to `measure instruction`.
Remove distinction between `measurement statement` and `measure instruction`.
General overview now explains that a cQASM program is a list of *statements*, of which the quantum algorithm is expressed by a sequence of *instructions*.
Add `version` token to version grammar.