### PR TITLE
[CQT-96] Fix deployment of latest for mkdocs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,8 @@ jobs:
             mkdocs build
 
       - name: Upload and tag as latest
-        if: github.ref == 'master'
+      
+        if: github.ref == 'refs/heads/master'
         run: |  
             mike deploy --push latest
             mike set-default --push latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,6 @@ jobs:
             mkdocs build
 
       - name: Upload and tag as latest
-      
         if: github.ref == 'refs/heads/master'
         run: |  
             mike deploy --push latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
             mike set-default --push latest
 
       - name: Upload and tag as git tag
-        if: startsWith(github.head_ref, 'releases/')
+        if: github.event_name == 'release' && github.event.action == 'created'
         run: |  
           mike deploy --push ${{ github.ref }}
           mike set-default --push latest


### PR DESCRIPTION
Update the way we trigger both the "master" and GitHub release jobs for deployments