### PR TITLE
Fix mike command reference in release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,5 +47,5 @@ jobs:
       - name: Upload and tag as git tag
         if: github.event_name == 'release' && github.event.action == 'created'
         run: |  
-          mike deploy --push ${{ github.ref }}
+          mike deploy --push ${{ github.ref_name }}
           mike set-default --push latest


### PR DESCRIPTION
Fixed mike command in release yaml to: `mike deploy --push ${{ github.ref_name }}`