### PR TITLE
Cqt 271 update spec with newly added instructions

### DIFF
--- a/docs/appendices/spin_2plus.md
+++ b/docs/appendices/spin_2plus.md
@@ -1,6 +1,6 @@
-# Spin-2
+# Spin-2+
 
-The Spin-2 system developed by QuTech supports the following subset of the cQASM language:
+The Spin-2+ system developed by QuTech supports the following subset of the cQASM language:
 
 * Multiple line comments in `/* … */` are supported.
 * Single line comments in `// …`, `# …`, `/* …*/` are supported.
@@ -13,7 +13,6 @@ The Spin-2 system developed by QuTech supports the following subset of the cQASM
 * The single-gate-multiple-qubit (SGMQ) notation is fully supported for single qubit gates
 * The SGMQ notation is not supported for two qubit gates.
 * The SGMQ notation results in a bundle resulting in a sequential list of gate operations.
-* Subcircuit headers are accepted (and subsequently ignored).
 * All other libqasm 1.x language structures are not supported.
 * No `prep_X` and `measure_X` instructions are allowed, the lls will init all supported qubits before circuit execution
   and measure all in the z-basis at the end of the circuit and only return the subset as defined in the qubit register.

--- a/docs/language_specification/general_overview.md
+++ b/docs/language_specification/general_overview.md
@@ -43,8 +43,12 @@ The unitary operations, commonly know as gates, can be either
 - Instructions:
     - [Unitary instructions](statements/instructions/unitary_instructions.md) (_i.e._, gates)
     - Non-unitary instructions:
+        - [Init instruction](statements/instructions/non_unitary_instructions/init_instruction.md)
         - [Measure instruction](statements/instructions/non_unitary_instructions/measure_instruction.md)
         - [Reset instruction](statements/instructions/non_unitary_instructions/reset_instruction.md)
+    - Control instructions:
+        - [Barrier instruction](statements/instructions/control_instructions/barrier_instruction.md)
+        - [Wait instruction](statements/instructions/control_instructions/wait_instruction.md)
    - [Single-gate-multiple-qubit (SGMQ) notation](statements/instructions/single-gate-multiple-qubit-notation.md)
 
 !!! example ""

--- a/docs/language_specification/statements/instructions/control_instructions/barrier_instruction.md
+++ b/docs/language_specification/statements/instructions/control_instructions/barrier_instruction.md
@@ -1,6 +1,7 @@
 The **`barrier`** instruction is a single-qubit control instruction
 that is used to constrain the optimization of a scheduler.
-It tells a scheduler that instructions on particular qubit(s) cannot be scheduled across the barrier.
+It tells a scheduler that instructions on the specified qubit(s) cannot be scheduled across the barrier.
+See the [**`wait`** instruction](wait_instruction.md), to impose a time delay following a barrier.
 
 The general form of the **`barrier`** instruction is as follows:
 
@@ -34,6 +35,11 @@ The general form of the **`barrier`** instruction is as follows:
     SGMQ notation does not guarantee simultaneity.
     This will depend on the scheduling optimization that is applied during the compilation process.
 
+    For certain backends, groups of consecutive **`barrier`** instructions are linked together to form a _uniform_
+    barrier, across which no instructions on the specified qubits can be scheduled.
+    Note that one can create a group of consecutive **`barrier`** instructions, _i.e._ a uniform barrier, using SGMQ
+    notation.
+
 !!! example
 
     === "Single qubit"
@@ -63,7 +69,7 @@ However, because of the presence of the **`barrier`** instruction the user expli
 **`q`** are not permitted to be optimized across the barrier.
 The second example shows that a barrier can be placed for multiple qubits.
 Note that the **`barrier`** instruction is applied to qubits **`q[0]`** and **`q[1]`**.
-Qubit **`q[2]`** can be optimized freely across the circuit, _i.e._, be scheduled before or after the barrier. 
+Qubit **`q[2]`** can be optimized freely across this circuit, _i.e._, be scheduled before or after the barrier. 
 
 The following code snippet illustrates how the **`barrier`** instruction might be used in context.
 
@@ -91,6 +97,7 @@ b[2, 3] = measure q
 ```
 
 In the above code snippet, the $\Phi_{+}$ and $\Psi_{+}$ Bell states are generated and measured, successively.
-The **`barrier`** instruction is used to guarantee that the **`measure`** instruction is scheduled _after_ the
-respective states have been generated. 
+The **`barrier`** instruction is used to guarantee that the
+[**`measure`** instruction](../non_unitary_instructions/measure_instruction.md) is scheduled _after_ the respective
+states have been generated. 
 Moreover, an extra **`barrier`** instruction is used to separate the generation and measurement of the two Bell states.

--- a/docs/language_specification/statements/instructions/control_instructions/barrier_instruction.md
+++ b/docs/language_specification/statements/instructions/control_instructions/barrier_instruction.md
@@ -1,0 +1,20 @@
+The general form of the barrier instruction is as follows:
+
+!!! info ""
+
+    &emsp;**`barrier`** _qubit-argument_
+
+??? info "Grammar for barrier instruction"
+    
+    _barrier-instruction_:  
+    &emsp; __`barrier`__ _qubit-argument_
+
+    _qubit-argument_:  
+    &emsp; _qubit-variable_  
+    &emsp; _qubit-index_
+
+    _qubit-variable_:  
+    &emsp; _identifier_
+
+    _qubit-index_:  
+    &emsp; _index_

--- a/docs/language_specification/statements/instructions/control_instructions/barrier_instruction.md
+++ b/docs/language_specification/statements/instructions/control_instructions/barrier_instruction.md
@@ -1,10 +1,14 @@
-The general form of the barrier instruction is as follows:
+The **`barrier`** instruction is a single-qubit control instruction
+that is used to constrain the optimization of a scheduler.
+It tells a scheduler that instructions on particular qubit(s) cannot be scheduled across the barrier.
+
+The general form of the **`barrier`** instruction is as follows:
 
 !!! info ""
 
     &emsp;**`barrier`** _qubit-argument_
 
-??? info "Grammar for barrier instruction"
+??? info "Grammar for **`barrier`** instruction"
     
     _barrier-instruction_:  
     &emsp; __`barrier`__ _qubit-argument_
@@ -18,3 +22,75 @@ The general form of the barrier instruction is as follows:
 
     _qubit-index_:  
     &emsp; _index_
+
+!!! note
+
+    The **`barrier`** instruction accepts
+    [SGMQ notation](../single-gate-multiple-qubit-notation.md), similar to gates.
+    Note, however, that SGMQ notation is _syntactic sugar_ to write a on a single line
+    the application of a single instruction to multiple qubits.
+    In general, a compiler will unpack this notation to separate consectutive
+    single-qubit instructions on the respective qubits.
+    SGMQ notation does not guarantee simultaneity.
+    This will depend on the scheduling optimization that is applied during the compilation process.
+
+!!! example
+
+    === "Single qubit"
+    
+        ```linenums="1", hl_lines="3"
+        qubit q
+        X q
+        barrier q
+        X q
+        ```
+    
+    === "Multiple qubits"
+    
+        ```linenums="1", hl_lines="3"
+        qubit[3] q
+        X q[0]
+        barrier q[0, 1]
+        H q[0]
+        X q[2]
+        H q[1]
+        ```
+
+In the examples above it is shown how the **`barrier`** instruction can be used with a single qubit and multiple qubits.
+In the case of the single qubit,
+an optimizer would generally fuse the two **`X`** gates into a single identity gate, **`I`**.
+However, because of the presence of the **`barrier`** instruction the user explicitly states that the instructions on
+**`q`** are not permitted to be optimized across the barrier.
+The second example shows that a barrier can be placed for multiple qubits.
+Note that the **`barrier`** instruction is applied to qubits **`q[0]`** and **`q[1]`**.
+Qubit **`q[2]`** can be optimized freely across the circuit, _i.e._, be scheduled before or after the barrier. 
+
+The following code snippet illustrates how the **`barrier`** instruction might be used in context.
+
+```linenums="1", hl_lines="9 12 19"
+version 3.0
+
+qubit[2] q
+init q
+
+// Phi+ state
+H q[0]
+CNOT q[0], q[1]
+barrier q
+b[0,1] = measure q
+
+barrier q
+reset q
+
+// Psi+ state
+H q[0]
+X q[1]
+CNOT q[0], q[1]
+barrier q
+b[2, 3] = measure q
+```
+
+In the above code snippet, the $\Phi_{+}$ and $\Psi_{+}$ Bell states are generated and measured, successively.
+The **`barrier`** instruction is used to guarantee that the **`measure`** instruction is scheduled _after_ the
+respective states have been generated. 
+Moreover, an extra **`barrier`** instruction is used to separate the generation and measurement of the two Bell states.

--- a/docs/language_specification/statements/instructions/control_instructions/wait_instruction.md
+++ b/docs/language_specification/statements/instructions/control_instructions/wait_instruction.md
@@ -1,0 +1,23 @@
+The general form of the wait instruction is as follows:
+
+!!! info ""
+
+    &emsp;__`wait(`__ _parameter_ __`)`__ _qubit-argument_
+
+??? info "Grammar for wait instruction"
+    
+    _wait-instruction_:  
+    &emsp;__`wait(`__ _parameter_ __`)`__ _qubit-argument_
+
+    _parameter_:  
+    &emsp; _integer-literal_ 
+
+    _qubit-argument_:  
+    &emsp; _qubit-variable_  
+    &emsp; _qubit-index_
+
+    _qubit-variable_:  
+    &emsp; _identifier_
+
+    _qubit-index_:  
+    &emsp; _index_

--- a/docs/language_specification/statements/instructions/control_instructions/wait_instruction.md
+++ b/docs/language_specification/statements/instructions/control_instructions/wait_instruction.md
@@ -1,10 +1,10 @@
-The general form of the wait instruction is as follows:
+The general form of the **`wait`** instruction is as follows:
 
 !!! info ""
 
     &emsp;__`wait(`__ _parameter_ __`)`__ _qubit-argument_
 
-??? info "Grammar for wait instruction"
+??? info "Grammar for **`wait`** instruction"
     
     _wait-instruction_:  
     &emsp;__`wait(`__ _parameter_ __`)`__ _qubit-argument_
@@ -21,3 +21,8 @@ The general form of the wait instruction is as follows:
 
     _qubit-index_:  
     &emsp; _index_
+
+!!! note
+
+    The **`wait`** instruction accepts
+    [SGMQ notation](../single-gate-multiple-qubit-notation.md), similar to gates.

--- a/docs/language_specification/statements/instructions/control_instructions/wait_instruction.md
+++ b/docs/language_specification/statements/instructions/control_instructions/wait_instruction.md
@@ -1,3 +1,22 @@
+The **`wait`** instruction is a single-qubit control instruction that is used to constrain the optimization of a
+scheduler.
+It tells the scheduler to delay the subsequent instructions on the specified qubit(s) by a given time.
+The delay time is passed along with the instruction as a dimensionless parameter,
+the unit of which represents the duration of a single-qubit gate on the backend,
+_i.e._, an execution cycle. 
+Moreover, the **`wait`** instruction will also function as a [_barrier_](barrier_instruction.md),
+telling the scheduler that instructions on the specified qubit(s) cannot be scheduled across the position of the 
+**`wait`** instruction.
+
+!!! warning
+
+    The [**`barrier`** instruction](barrier_instruction.md) may be considered equal to the **`wait`** instruction with a
+    time delay set to 0.
+    Note however that for certain backends, groups of consecutive **`barrier`** instructions are linked together to
+    form a _uniform_ barrier, across which no instructions on the specified qubits can be scheduled.
+    This is **not** the case for the **`wait`** instruction; consecutive **`wait`** instructions are always considered
+    to be independent instructions.
+
 The general form of the **`wait`** instruction is as follows:
 
 !!! info ""
@@ -26,3 +45,53 @@ The general form of the **`wait`** instruction is as follows:
 
     The **`wait`** instruction accepts
     [SGMQ notation](../single-gate-multiple-qubit-notation.md), similar to gates.
+
+!!! example
+
+    === "Single qubit"
+    
+        ```linenums="1", hl_lines="3"
+        qubit q
+        X q
+        wait(5) q  // time delay of 5 execution cycles
+        X q
+        ```
+    
+    === "Multiple qubits"
+    
+        ```linenums="1", hl_lines="3"
+        qubit[3] q
+        X q[0]
+        wait(5) q[0, 1]  // time delay of 5 execution cycles
+        H q[0]
+        X q[2]
+        H q[1]
+        ```
+
+In the examples above it is shown how the **`wait`** instruction can be used with a single qubit and multiple qubits.
+In the case of the single qubit, the **`wait`** instruction tells the scheduler to schedule a delay of 5 execution
+cycles between the successive **`X`** gates.
+Note that it also implicitly places a [barrier](barrier_instruction.md) between the two **`X`** gates,
+such that they cannot be fused into a single identity gate, **`I`**.
+In the second example, using SGMQ notation, the **`wait`** instruction is applied to qubits **`q[0]`** and **`q[1]`**.
+Enforcing a delay of 5 execution cycles on any following instructions involving those qubits,
+_e.g._, here **`H q[0]`** and **`H q[1]`**.
+Qubit **`q[2]`** can be optimized freely across this circuit,
+_i.e._, be scheduled before or after **`wait`** instruction, regardless of any specified time delay. 
+
+The following code snippet illustrates how the **`wait`** instruction might be used in context.
+
+```linenums="1", hl_lines="7"
+version 3.0
+
+qubit[2] q
+bit[2] b
+init q
+
+wait(100) q[0]
+b[0] = measure q[0]
+```
+
+Here, the [measurement](../non_unitary_instructions/measure_instruction.md) of **`q[0]`** is forced to be scheduled at
+least 100 execution cycles after the [initialization](../non_unitary_instructions/init_instruction.md)
+of the qubit is complete.

--- a/docs/language_specification/statements/instructions/non_unitary_instructions/init_instruction.md
+++ b/docs/language_specification/statements/instructions/non_unitary_instructions/init_instruction.md
@@ -1,12 +1,13 @@
-A **`init`** instruction initializes the state of the qubit to $|0\rangle$.
-
-The general form of an init instruction is as follows:
+In general, qubits are initialized in the $|0\rangle$ state.
+Nonetheless, to explicitly initialize (particular) qubits in the $|0\rangle$ state
+one can use the **`init`** instruction.
+The general form of an **`init`** instruction is as follows:
 
 !!! info ""
 
     &emsp;**`init`** _qubit-argument_
 
-??? info "Grammar for init instruction"
+??? info "Grammar for **`init`** instruction"
     
     _init-instruction_:  
     &emsp; __`init`__ _qubit-argument_
@@ -39,10 +40,10 @@ The general form of an init instruction is as follows:
 
 !!! note
 
-    The init instruction accepts
+    The **`init`** instruction accepts
     [SGMQ notation](../single-gate-multiple-qubit-notation.md), similar to gates.
 
-The following code snippet shows how the reset instruction might be used in context.
+The following code snippet shows how the **`init`** instruction might be used in context.
 
 ```linenums="1" hl_lines="6"
 version 3.0
@@ -58,8 +59,45 @@ CNOT q[0], q[1]
 b = measure q
 ```
 
-_explanation_
+The code example above, the qubits are first declared and subsequently initialized.
+Note that the initialization of qubits needs to be done before any instructions
+(excluding the [**`barrier`**](../control_instructions/barrier_instruction.md)
+and [**`wait`**](../control_instructions/wait_instruction.md) control instructions)
+are applied to them (see warning below).
+If one wishes to _reset_ the state of the qubit to $|0\rangle$ mid-circuit,
+one should use the [**`reset`**](../non_unitary_instructions/reset_instruction.md) instruction.
 
-!!! info
+
+!!! warning
     
-    _Initialization of qubits can only be done immediately after declaration._
+    Initialization of a qubit can only be done immediately after declaration of the qubit, _i.e._, 
+    it is not possible to initialize a qubit, if prior to that an instruction was applied to the qubit
+    (excluding the [barrier](../control_instructions/barrier_instruction.md)
+    and [wait](../control_instructions/wait_instruction.md) control instructions).
+
+    === "Invalid initialization"
+        
+        ```linenums="1" hl_lines="8"
+        version 3.0
+    
+        qubit[2] q
+
+        barrier q  // Control instructions may be applied to qubits before initialization
+        H q[1]
+
+        init q[1]  // Invalid use, since the H gate was applied to q[1] before initialization
+        ```
+
+    === "Valid initialization"
+        
+        ```linenums="1" hl_lines="8"
+        version 3.0
+    
+        qubit[2] q
+    
+        barrier q  // Control instructions may be applied to qubits before initialization
+        H q[1]
+
+        init q[0]  // Valid use, because no instruction is applied to q[0] before initalization
+        ```
+    

--- a/docs/language_specification/statements/instructions/non_unitary_instructions/init_instruction.md
+++ b/docs/language_specification/statements/instructions/non_unitary_instructions/init_instruction.md
@@ -1,0 +1,65 @@
+A **`init`** instruction initializes the state of the qubit to $|0\rangle$.
+
+The general form of an init instruction is as follows:
+
+!!! info ""
+
+    &emsp;**`init`** _qubit-argument_
+
+??? info "Grammar for init instruction"
+    
+    _init-instruction_:  
+    &emsp; __`init`__ _qubit-argument_
+
+    _qubit-argument_:  
+    &emsp; _qubit-variable_  
+    &emsp; _qubit-index_
+
+    _qubit-variable_:  
+    &emsp; _identifier_
+
+    _qubit-index_:  
+    &emsp; _index_
+
+!!! example
+
+    === "Initialize a single qubit"
+    
+        ```linenums="1", hl_lines="2"
+        qubit q
+        init q
+        ```
+    
+    === "Initialize multiple qubits through their register index"
+    
+        ```linenums="1", hl_lines="2"
+        qubit[5] q
+        init q[2, 4]
+        ```
+
+!!! note
+
+    The init instruction accepts
+    [SGMQ notation](../single-gate-multiple-qubit-notation.md), similar to gates.
+
+The following code snippet shows how the reset instruction might be used in context.
+
+```linenums="1" hl_lines="6"
+version 3.0
+
+qubit[2] q
+bit[2] b
+
+init q  // Initializes the qubits to |0>
+
+H q[0]
+CNOT q[0], q[1]
+
+b = measure q
+```
+
+_explanation_
+
+!!! info
+    
+    _Initialization of qubits can only be done immediately after declaration._

--- a/docs/language_specification/statements/instructions/non_unitary_instructions/measure_instruction.md
+++ b/docs/language_specification/statements/instructions/non_unitary_instructions/measure_instruction.md
@@ -1,12 +1,12 @@
 A **`measure`** instruction performs a measurement to its qubit argument and
 assigns the outcome to a bit variable.
-The general form of a measure instruction is as follows:
+The general form of a **`measure`** instruction is as follows:
 
 !!! info ""
 
     &emsp;_bit-argument_ **`=`** **`measure`** _qubit-argument_
 
-??? info "Grammar for measure instruction"
+??? info "Grammar for **`measure`** instruction"
     
     _measure-instruction_:  
     &emsp; _bit-argument_ __`=`__ __`measure`__ _qubit-argument_
@@ -51,10 +51,10 @@ The general form of a measure instruction is as follows:
 
 !!! note
 
-    The measure instruction accepts
+    The **`measure`** instruction accepts
     [SGMQ notation](../single-gate-multiple-qubit-notation.md), similar to gates.
 
-The following code snippet shows how the measure instruction might be used in context.
+The following code snippet shows how the **`measure`** instruction might be used in context.
 
 ```linenums="1" hl_lines="9"
 version 3.0

--- a/docs/language_specification/statements/instructions/non_unitary_instructions/reset_instruction.md
+++ b/docs/language_specification/statements/instructions/non_unitary_instructions/reset_instruction.md
@@ -19,7 +19,6 @@ The general form of a reset instruction is as follows:
 ??? info "Grammar for reset instruction"
     
     _reset-instruction_:  
-    &emsp; __`reset`__  
     &emsp; __`reset`__ _qubit-argument_
 
     _qubit-argument_:  
@@ -33,14 +32,6 @@ The general form of a reset instruction is as follows:
     &emsp; _index_
 
 !!! example
-    
-    === "Reset of all the qubits"
-    
-        ```linenums="1", hl_lines="3"
-        qubit q
-        qubit[5] qq
-        reset
-        ```
     
     === "Reset of a single qubit"
     

--- a/docs/language_specification/statements/instructions/non_unitary_instructions/reset_instruction.md
+++ b/docs/language_specification/statements/instructions/non_unitary_instructions/reset_instruction.md
@@ -3,20 +3,20 @@ It does this by first measuring the qubit and then, conditioned on the outcome b
 
 !!! note
     
-    Even though the `reset` instruction internally measures the qubit state,
+    Even though the **`reset`** instruction internally measures the qubit state,
     it does not store the measurement outcome in the measurement register,
-    _i.e._, the measurement register is unaffected by the `reset` instruction.
+    _i.e._, the measurement register is unaffected by the **`reset`** instruction.
     The measurement outcome is only used to determine whether or not
     a Pauli X gate needs to be performed, in order to bring the qubit
     into the state $|0\rangle$.
 
-The general form of a reset instruction is as follows:
+The general form of a **`reset`** instruction is as follows:
 
 !!! info ""
 
     &emsp;**`reset`** _qubit-argument_
 
-??? info "Grammar for reset instruction"
+??? info "Grammar for **`reset`** instruction"
     
     _reset-instruction_:  
     &emsp; __`reset`__ _qubit-argument_
@@ -49,10 +49,10 @@ The general form of a reset instruction is as follows:
 
 !!! note
 
-    The reset instruction accepts
+    The **`reset`** instruction accepts
     [SGMQ notation](../single-gate-multiple-qubit-notation.md), similar to gates.
 
-The following code snippet shows how the reset instruction might be used in context.
+The following code snippet shows how the **`reset`** instruction might be used in context.
 
 ```linenums="1" hl_lines="9"
 version 3.0
@@ -68,15 +68,15 @@ reset q[0]  // Resets the state of qubit q[0] to |0>
 b = measure q
 ```
 
-The `reset` instruction is performed by measuring `q[0]` along the computational basis.
+The **`reset`** instruction is performed by measuring **`q[0]`** along the computational basis.
 Based on the measurement outcome, either no operation is performed (in case the outcome is 0) or
 a Pauli X gate is applied (in case the outcome is 1).
-The result of the subsequent `measure` instruction will be `00` in roughly half of the cases
-and `10` in the remaining cases,
-with the qubit register indices decreasing from left to right, _i.e._, `q[n]...q[0]`.
+The result of the subsequent **`measure`** instruction will be **`00`** in roughly half of the cases
+and **`10`** in the remaining cases,
+with the qubit register indices decreasing from left to right, _i.e._, **`q[n]...q[0]`**.
 
 !!! info
     
     Qubits that are part of an entangled state,
     are disentangled from that state,
-    when the `reset` instruction is applied to them.
+    when the **`reset`** instruction is applied to them.

--- a/docs/language_specification/statements/instructions/unitary_instructions.md
+++ b/docs/language_specification/statements/instructions/unitary_instructions.md
@@ -131,7 +131,7 @@ A few examples of gates are shown below.
 | CNOT | Controlled-NOT gate                      | **`CNOT q[0], q[1]`**   |
 | CZ   | Controlled-Z, Controlled-Phase           | **`CZ q[0], q[1]`**     |
 | CR   | Controlled phase shift (arbitrary angle) | **`CR(pi) q[0], q[1]`** |
-| CRk  | Controlled phase shift ($\pi/2^k$)       | **`CRk(2) q[0], q[1]`** |
+| CRk  | Controlled phase shift ($\pi/2^{k-1}$)   | **`CRk(2) q[0], q[1]`** |
 | SWAP | Swap gate                                | **`SWAP q[0], q[1]`**   |
 
 ## Gate modifiers

--- a/docs/language_specification/statements/instructions/unitary_instructions.md
+++ b/docs/language_specification/statements/instructions/unitary_instructions.md
@@ -132,6 +132,7 @@ A few examples of gates are shown below.
 | CZ   | Controlled-Z, Controlled-Phase           | **`CZ q[0], q[1]`**     |
 | CR   | Controlled phase shift (arbitrary angle) | **`CR(pi) q[0], q[1]`** |
 | CRk  | Controlled phase shift ($\pi/2^k$)       | **`CRk(2) q[0], q[1]`** |
+| SWAP | Swap gate                                | **`SWAP q[0], q[1]`**   |
 
 ## Gate modifiers
 

--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -26,8 +26,12 @@ nav:
       - Instructions:
         - Unitary instructions: ./language_specification/statements/instructions/unitary_instructions.md
         - Non-unitary instructions:
+          - Init instruction: ./language_specification/statements/instructions/non_unitary_instructions/init_instruction.md
           - Measure instruction: ./language_specification/statements/instructions/non_unitary_instructions/measure_instruction.md
           - Reset instruction: ./language_specification/statements/instructions/non_unitary_instructions/reset_instruction.md
+        - Control instructions:
+          - Barrier instruction: ./language_specification/statements/instructions/control_instructions/barrier_instruction.md
+          - Wait instruction: ./language_specification/statements/instructions/control_instructions/wait_instruction.md
         - Single-gate-multiple-qubit (SGMQ) notation: ./language_specification/statements/instructions/single-gate-multiple-qubit-notation.md
     - Types: ./language_specification/types.md
     - Expressions:
@@ -35,7 +39,7 @@ nav:
       - Predefined constants: ./language_specification/expressions/predefined_constants.md
       - Built-in functions: ./language_specification/expressions/builtin_functions.md
   - Appendices:
-      - Spin-2: appendices/spin_2.md
+      - Spin-2+: appendices/spin_2plus.md
 
 theme:
   name: material


### PR DESCRIPTION
- Add SWAP gate to standard gate set
- Add docs for:
  - init (non-unitary) instruction
  - barrier (control) instruction
  - wait (control) instruction
- minor format changes to other pages