### PR TITLE
[CQT-382] Assembly declarations should be ignored by Spin-2 parser 

### DIFF
--- a/docs/appendices/spin_2plus.md
+++ b/docs/appendices/spin_2plus.md
@@ -16,5 +16,10 @@ The Spin-2+ system developed by QuTech supports the following subset of the cQAS
 * All other libqasm 1.x language structures are not supported.
 * No `prep_X` and `measure_X` instructions are allowed, the lls will init all supported qubits before circuit execution
   and measure all in the z-basis at the end of the circuit and only return the subset as defined in the qubit register.
-* Bit register declaration statements, _e.g._, `bit[<number-of-bits:INT>] <bit-register-name:ID>` or `bit <bit-name:ID>`, are accepted and subsequently ignored.
-* Measure instruction statements assign outcomes to bit variables, _e.g._ `<bit-name:BIT> = measure <qubit-argument:QUBIT>`. These statements are accepted and subsequently ignored.
+* Bit register declaration statements, _e.g._,
+`bit[<number-of-bits:INT>] <bit-register-name:ID>` or `bit <bit-name:ID>`, are accepted and subsequently ignored.
+* Measure instruction statements assign outcomes to bit variables,
+_e.g._ `<bit-name:BIT> = measure <qubit-argument:QUBIT>`. These statements are accepted and subsequently ignored.
+* Assembly declaration statements, e.g., `asm(<backend-name>) ''' <backend-code> '''`,
+are accepted and subsequently ignored.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,18 @@
-This documentation describes the language specification of the cQASM quantum programming language, version 3.0-beta1.
+This documentation describes the language specification of the cQASM quantum programming language, version 3.0.
 cQASM stands for common Quantum ASseMbly language, and is pronounced _c-kazem_.
 
-cQASM 3.0-beta1 supersedes the [cQASM 1.[012] languages](https://libqasm.readthedocs.io/en/latest/) and [cQASM 2.0 language specification](https://github.com/QuTech-Delft/cQASM-spec/tree/2.0-draft-2), the latter of which remains incomplete.
+cQASM 3.0 supersedes the [cQASM 1.[012] languages](https://libqasm.readthedocs.io/en/latest/) and [cQASM 2.0 language specification](https://github.com/QuTech-Delft/cQASM-spec/tree/2.0-draft-2), the latter of which remains incomplete.
 
 !!! note
 
-    Even though cQASM 3.0-beta1 is conceptually similar to previous language specifications, it is not a straightforward extension thereof; the syntax and grammar of cQASM 3.0-beta1 differ fundamentally from its predecessors. These changes break backwards compatibility.
+    Even though cQASM 3.0 is conceptually similar to previous language specifications, it is not a straightforward extension thereof; the syntax and grammar of cQASM 3.0 differ fundamentally from its predecessors. These changes break backwards compatibility.
 
 In the rest of the documentation we will drop the version label of language and simply refer to it as the cQASM language.
 
 !!! warning
 
     The cQASM language is currently under active development. 
-    cQASM 3.0-beta1 serves as a minimum viable product; to be used as a baseline version for the further development of, _e.g._, the [libQASM](https://github.com/QuTech-Delft/libqasm) language parser library, [OpenSquirrel](https://github.com/QuTech-Delft/OpenSquirrel) quantum algorithm compiler, and [QX simulator](https://github.com/QuTech-Delft/qx-simulator).
+    cQASM 3.0 serves as a minimum viable product; to be used as a baseline version for the further development of, _e.g._, the [libQASM](https://github.com/QuTech-Delft/libqasm) language parser library, [OpenSquirrel](https://github.com/QuTech-Delft/OpenSquirrel) quantum algorithm compiler, and [QX simulator](https://github.com/QuTech-Delft/qx-simulator).
     The cQASM specification will be updated as new features are introduced to the language.
     Where applicable, these features are then also implemented in the aformentioned software components, in an iterative fashion.
     

--- a/docs/language_specification/statements/assembly_declaration.md
+++ b/docs/language_specification/statements/assembly_declaration.md
@@ -1,6 +1,7 @@
 Assembly declarations can be used to add backend-specific (assembly) code to a cQASM circuit.
 They are realized through an **`asm`** _declaration_ statement.
-An **`asm`** declaration statement consists of the keyword **`asm`** with the identifier of the backend in parentheses,
+An **`asm`** declaration statement consists of the keyword **`asm`** with the
+[identifier](../tokens/identifiers.md) of the backend in parentheses,
 followed by the backend code.
 The latter is to be provided as a [_raw text string_](../tokens/raw_text_string.md),
 which consists of a _raw text_ delimited by opening and closing triple quotes (**`'''`**):


### PR DESCRIPTION
- Generalize version number in text to 3.0.
- Add sentence on assembly declarations to Spin-2+ appendix. 
- Add link to identifiers in asm declarations to highlight backend-name grammar.